### PR TITLE
Updated changes from stable-baselines update.

### DIFF
--- a/utils/noise.py
+++ b/utils/noise.py
@@ -1,5 +1,10 @@
 import numpy as np
-from stable_baselines.common.noise import ActionNoise
+# TODO: remove when stable-baselines > 2.8.0 is out
+try:
+    # The base noise class was moved to the common folder
+    from stable_baselines.common.noise import ActionNoise
+except ImportError:
+    from stable_baselines.ddpg.noise import ActionNoise
 
 
 class LinearNormalActionNoise(ActionNoise):

--- a/utils/noise.py
+++ b/utils/noise.py
@@ -1,5 +1,5 @@
 import numpy as np
-from stable_baselines.ddpg.noise import ActionNoise
+from stable_baselines.common.noise import ActionNoise
 
 
 class LinearNormalActionNoise(ActionNoise):


### PR DESCRIPTION
`python train.py` fails because ActionNoise as changed locations in the main stable-baselines repo. This fixes import from `ddpg` to `common`