### PR TITLE
Check if hyperparams is None

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -158,6 +158,9 @@ def create_test_env(env_id, n_envs=1, is_atari=False,
         os.makedirs(log_dir, exist_ok=True)
         logger.configure()
 
+    if hyperparams is None:
+        hyperparams = {}
+
     # Create the environment and wrap it if necessary
     env_wrapper = get_wrapper_class(hyperparams)
     if 'env_wrapper' in hyperparams.keys():


### PR DESCRIPTION
Set `hyperparams={}` if it is equal to `None`, avoiding an **AttributeError**:
https://github.com/araffin/rl-baselines-zoo/blob/da52f568282de8e3b0a7435eb64c752d00568ca3/utils/utils.py#L163

Resolves https://github.com/araffin/rl-baselines-zoo/issues/54.