### PR TITLE
Add support for CartPoleContinuousBulletEnvs-v0

### DIFF
--- a/hyperparams/ppo2.yml
+++ b/hyperparams/ppo2.yml
@@ -38,6 +38,33 @@ CartPole-v1:
   learning_rate: lin_0.001
   cliprange: lin_0.2
 
+CartPoleBulletEnv-v1:
+  n_envs: 8
+  n_timesteps: !!float 1e5
+  policy: 'MlpPolicy'
+  n_steps: 32
+  nminibatches: 1
+  lam: 0.8
+  gamma: 0.98
+  noptepochs: 20
+  ent_coef: 0.0
+  learning_rate: lin_0.001
+  cliprange: lin_0.2
+
+CartPoleContinuousBulletEnv-v0:
+  n_envs: 8
+  n_timesteps: !!float 1e5
+  policy: 'MlpPolicy'
+  n_steps: 32
+  nminibatches: 1
+  lam: 0.8
+  gamma: 0.98
+  noptepochs: 20
+  ent_coef: 0.0
+  learning_rate: lin_0.001
+  cliprange: lin_0.2
+
+
 MountainCar-v0:
   normalize: true
   n_envs: 16


### PR DESCRIPTION
Add support for CartPoleContinuousBulletEnvs-v0 and CartPoleBulletEnvs-v1 (discrete action space)

python3 train.py --env CartPoleContinuousBulletEnv-v0 --algo ppo2
or see this Colab:
https://colab.sandbox.google.com/drive/15JSROMJbeiqxcUwifPR2NYeeFBKmyIlX#scrollTo=E2eWDjPZsQc5