### PR TITLE
Optional keyword argument to pass to the env constructor. Solve #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ env_wrapper:
 
 Note that you can easily specify parameters too.
 
+## Env keyword arguments
+
+You can specify keyword arguments to pass to the env constructor in the command line, using `--env-kwargs`:
+
+```
+python enjoy.py --algo ppo2 --env MountainCar-v0 --env-kwargs goal_velocity:10
+```
+
 ## Overwrite hyperparameters
 
 You can easily overwrite hyperparameters in the command line, using ``--hyperparams``:

--- a/enjoy.py
+++ b/enjoy.py
@@ -17,6 +17,7 @@ from stable_baselines.common import set_global_seeds
 from stable_baselines.common.vec_env import VecNormalize, VecFrameStack, VecEnv
 
 from utils import ALGOS, create_test_env, get_latest_run_id, get_saved_hyperparams, find_saved_model
+from utils.utils import StoreDict
 
 # Fix for breaking change in v2.6.0
 sys.modules['stable_baselines.ddpg.memory'] = stable_baselines.common.buffers
@@ -50,6 +51,7 @@ def main():
     parser.add_argument('--seed', help='Random generator seed', type=int, default=0)
     parser.add_argument('--reward-log', help='Where to log reward', default='', type=str)
     parser.add_argument('--gym-packages', type=str, nargs='+', default=[], help='Additional external Gym environemnt package modules to import (e.g. gym_minigrid)')
+    parser.add_argument('--env-kwargs', type=str, nargs='+', action=StoreDict, help='Optional keyword argument to pass to the env constructor')
     args = parser.parse_args()
 
     # Going through custom gym packages to let them register in the global registory
@@ -87,10 +89,12 @@ def main():
 
     log_dir = args.reward_log if args.reward_log != '' else None
 
+    env_kwargs = {} if args.env_kwargs is None else args.env_kwargs
+
     env = create_test_env(env_id, n_envs=args.n_envs, is_atari=is_atari,
                           stats_path=stats_path, seed=args.seed, log_dir=log_dir,
                           should_render=not args.no_render,
-                          hyperparams=hyperparams)
+                          hyperparams=hyperparams, env_kwargs=env_kwargs)
 
     # ACER raises errors because the environment passed must have
     # the same number of environments as the model was trained on.

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -149,7 +149,7 @@ def get_wrapper_class(hyperparams):
         return None
 
 
-def make_env(env_id, rank=0, seed=0, log_dir=None, wrapper_class=None, env_kwargs={}):
+def make_env(env_id, rank=0, seed=0, log_dir=None, wrapper_class=None, env_kwargs=None):
     """
     Helper function to multiprocess training
     and log the progress.
@@ -160,10 +160,13 @@ def make_env(env_id, rank=0, seed=0, log_dir=None, wrapper_class=None, env_kwarg
     :param log_dir: (str)
     :param wrapper: (type) a subclass of gym.Wrapper to wrap the original
                     env with
-    :param env_kwargs=(dict) Optional keyword argument to pass to the env constructor
+    :param env_kwargs: (Dict[str, Any]) Optional keyword argument to pass to the env constructor
     """
     if log_dir is not None:
         os.makedirs(log_dir, exist_ok=True)
+
+    if env_kwargs is None:
+        env_kwargs = {}
 
     def _init():
         set_global_seeds(seed + rank)
@@ -185,7 +188,7 @@ def make_env(env_id, rank=0, seed=0, log_dir=None, wrapper_class=None, env_kwarg
 
 def create_test_env(env_id, n_envs=1, is_atari=False,
                     stats_path=None, seed=0,
-                    log_dir='', should_render=True, hyperparams=None, env_kwargs={}):
+                    log_dir='', should_render=True, hyperparams=None, env_kwargs=None):
     """
     Create environment for testing a trained agent
 
@@ -199,7 +202,7 @@ def create_test_env(env_id, n_envs=1, is_atari=False,
     :param env_wrapper: (type) A subclass of gym.Wrapper to wrap the original
                         env with
     :param hyperparams: (dict) Additional hyperparams (ex: n_stack)
-    :param env_kwargs=(dict) Optional keyword argument to pass to the env constructor
+    :param env_kwargs: (Dict[str, Any]) Optional keyword argument to pass to the env constructor
     :return: (gym.Env)
     """
     # HACK to save logs
@@ -211,6 +214,9 @@ def create_test_env(env_id, n_envs=1, is_atari=False,
 
     if hyperparams is None:
         hyperparams = {}
+
+    if env_kwargs is None:
+        env_kwargs = {}
 
     # Create the environment and wrap it if necessary
     env_wrapper = get_wrapper_class(hyperparams)


### PR DESCRIPTION
I coded the necessary changes to allow users of the RL Baseline Zoo to pass additional parameters for the environment's constructor.

This is useful when using customized environments. Ideally the environments should be fixed, but especially during development phase it's very helpful to pass additional optional parameters. This solves the question #58.
closes #58 .

For the parameter name ( `env_kwargs`) I chose the same as in `stable_baselines.common.cmd_util.make_vec_env`.

I've used the tests of the repository and it seems all be ok.