### PR TITLE
Wrapping eval_env with HERGoalEnvWrapper when necessary

### DIFF
--- a/train.py
+++ b/train.py
@@ -29,6 +29,7 @@ from stable_baselines.common.vec_env import VecFrameStack, SubprocVecEnv, VecNor
 from stable_baselines.common.noise import AdaptiveParamNoiseSpec, NormalActionNoise, OrnsteinUhlenbeckActionNoise
 from stable_baselines.common.schedules import constfn
 from stable_baselines.common.callbacks import CheckpointCallback, EvalCallback
+from stable_baselines.her import HERGoalEnvWrapper
 
 from utils import make_env, ALGOS, linear_schedule, get_latest_run_id, get_wrapper_class, find_saved_model
 from utils.hyperparams_opt import hyperparam_optimization
@@ -271,6 +272,8 @@ if __name__ == '__main__':
             env = VecFrameStack(env, n_stack)
             print("Stacking {} frames".format(n_stack))
             del hyperparams['frame_stack']
+        if args.algo == 'her' and eval_env:
+            env = HERGoalEnvWrapper(env)
         return env
 
 

--- a/utils/hyperparams_opt.py
+++ b/utils/hyperparams_opt.py
@@ -112,7 +112,6 @@ def hyperparam_optimization(algo, model_fn, env_fn, n_trials=10, n_timesteps=500
             # Wrap the env if need to flatten the dict obs
             if isinstance(eval_env, VecEnv):
                 eval_env = _UnvecWrapper(eval_env)
-            eval_env = HERGoalEnvWrapper(eval_env)
 
         try:
             model.learn(n_timesteps, callback=eval_callback)

--- a/utils/hyperparams_opt.py
+++ b/utils/hyperparams_opt.py
@@ -8,7 +8,6 @@ from optuna.integration.skopt import SkoptSampler
 from stable_baselines import SAC, TD3
 from stable_baselines.common.noise import AdaptiveParamNoiseSpec, NormalActionNoise, OrnsteinUhlenbeckActionNoise
 from stable_baselines.common.vec_env import VecNormalize, VecEnv
-from stable_baselines.her import HERGoalEnvWrapper
 from stable_baselines.common.base_class import _UnvecWrapper
 
 # Load mpi4py-dependent algorithms only if mpi is installed. (c.f. stable-baselines v2.10.0)


### PR DESCRIPTION
This PR gets rid of the warning when using HER, see issue #77.

```bash
UserWarning: Training and eval env are not of the same type<stable_baselines.her.utils.HERGoalEnvWrapper object at 0x7f68828e7be0> != <stable_baselines.common.vec_env.dummy_vec_env.DummyVecEnv object at 0x7f686266ea58>
  "{} != {}".format(self.training_env, self.eval_env))
```

Steps to reproduce:
```bash
python train.py --algo her --env parking-v0 -n 10000
```

A PR for Stable Baselines will be submitted as it is now necessary to flatten observations in `HERGoalEnvWrapper`